### PR TITLE
Remove form/page references from setters

### DIFF
--- a/Config/configPage.html
+++ b/Config/configPage.html
@@ -114,13 +114,13 @@
                 var form = this;
 
                 ApiClient.getPluginConfiguration(SyncConfigurationPage.pluginUniqueId).then(function (config) {
-                    config.LDAPServer = $('#txtLdapServer',form).val();
-                    config.LdapBaseDn = $('#txtLdapBaseDn',form).val();
-                    config.LdapQuery = $('#txtLdapQuery',form).val();
-                    config.LdapBindUser = $('#txtLdapBindUser',form).val();
-                    config.LdapBindPassword = $('#txtLdapBindPassword',form).val();
-                    config.CreateUsersFromLdap = $("#chkEnableUserCreation", page).checked();
-                    config.LdapPort = parseInt($("#txtLdapPort", page).val() || "389");
+                    config.LDAPServer = $('#txtLdapServer').val();
+                    config.LdapBaseDn = $('#txtLdapBaseDn').val();
+                    config.LdapQuery = $('#txtLdapQuery').val();
+                    config.LdapBindUser = $('#txtLdapBindUser').val();
+                    config.LdapBindPassword = $('#txtLdapBindPassword').val();
+                    config.CreateUsersFromLdap = $("#chkEnableUserCreation").checked();
+                    config.LdapPort = parseInt($("#txtLdapPort").val() || "389");
                     ApiClient.updatePluginConfiguration(SyncConfigurationPage.pluginUniqueId, config).then(Dashboard.processPluginConfigurationUpdateResult);              
                 });
 

--- a/Config/configPage.html
+++ b/Config/configPage.html
@@ -21,10 +21,10 @@
                             </div>
                         </li>
                         <li>
-                            <label for="txtLdapBaseDN">
+                            <label for="txtLdapBaseDn">
                                 LDAP Base DN for searches:
                             </label>
-                            <input type="text" id="txtLdapBaseDN" name="txtLdapBaseDN" />
+                            <input type="text" id="txtLdapBaseDn" name="txtLdapBaseDn" />
                             <div class="fieldDescription">
                                 The base DN structure for your LDAP query
                             </div>


### PR DESCRIPTION
Two were misnamed and were failing, but they are not required at all.

Also forgot a single capitalization rename from #1, `BaseDN` -> `BaseDn`.